### PR TITLE
Create references.html

### DIFF
--- a/_includes/references.html
+++ b/_includes/references.html
@@ -1,0 +1,15 @@
+{% if page.references %}
+{% capture reference_block %}
+## References
+
+{% for refs in page.references %}
+  {% if refs[1] %} <!-- is object -->
+    1. [{{refs[1]}}]({{refs[1]}})
+  {% else %} <!-- is array -->
+    * [{{refs}}]({{refs}})
+  {% endif %}
+{% endfor %}
+{% endcapture %}
+
+{{ reference_block | markdownify }}
+{% endif %}


### PR DESCRIPTION
Add a include for references at the end of the page.
# Activate references.html

Placed `{% include references.html %}` into a template in your jekyll site.  Then use either an array or object to create the list in a post or page.
# Array

```
references: # this is the trigger
- http://a.com
- http://b.com
```

then they are referenced as `{{references[0]}}`.and `{{references[0]}}`
# Object

```
references: # this is the trigger
  pubmed: http://a.com
  natgeo: http://b.com
```

then they are referenced as `{{references.pubmed}}`.and `{{references.natgeo}}`
